### PR TITLE
update to latest ironpython3 to get ironPython working on net10 builds of sandbox / revit.

### DIFF
--- a/IronPython3Extension/IronPython3Extension.csproj
+++ b/IronPython3Extension/IronPython3Extension.csproj
@@ -17,8 +17,8 @@
 		   <PrivateAssets>all</PrivateAssets>
       <ExcludeAssets></ExcludeAssets>
 		</PackageReference>
-    <PackageReference Include="IronPython" Version="3.4.1" />
-    <PackageReference Include="IronPython.StdLib" Version="3.4.1" />
+    <PackageReference Include="IronPython" Version="3.4.2" />
+    <PackageReference Include="IronPython.StdLib" Version="3.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/python3eval/python3eval.csproj
+++ b/python3eval/python3eval.csproj
@@ -20,10 +20,10 @@
       <ExcludeAssets>runtime</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="IronPython" Version="3.4.1">
+    <PackageReference Include="IronPython" Version="3.4.2">
       <IncludeAssets></IncludeAssets>
     </PackageReference>
-    <PackageReference Include="IronPython.StdLib" Version="3.4.1" />
+    <PackageReference Include="IronPython.StdLib" Version="3.4.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
There seems to be a bug that stops ironPython 3.4.1 from running on net 9 or net 10 runtimes. It's fixed in this version of ironPython.

These are just the minimal changes I needed to make this work - ideally we'd update the other refs and targetframeworks - but this works.